### PR TITLE
Smartthings plugin fixes

### DIFF
--- a/plugin-examples/smartthings.py
+++ b/plugin-examples/smartthings.py
@@ -72,6 +72,8 @@ class SmartthingsPlugin(BasePlugin):
         if partition == '' or status == '':
           logging.debug("Partition or status was empty, skipping this event. NOTE: This may be an error, if so we need to get a proper status for whatever even this is to fix it")
           return
+        else:
+          logging.debug("Status code was: %s", status)
 
         # Better error handling..
         try:


### PR DESCRIPTION
Don't crash when we receive an event we don't have a corresponding action for.
Additional debug output.
