### PR TITLE
Smartthings config must match class name

### DIFF
--- a/plugin-examples/SmartthingsPlugin-example.cfg
+++ b/plugin-examples/SmartthingsPlugin-example.cfg
@@ -1,4 +1,4 @@
-## copy this file to smartthingsPlugin.cfg and set the values appropriately
+## copy this file to SmartthingsPlugin.cfg and set the values appropriately
 [smartthings]
 callbackurl_base = https://graph.api.smartthings.com/api/smartapps/installations
 callbackurl_app_id = <your app id here>


### PR DESCRIPTION
It took a few minutes of digging through the code to figure out why the config for this plugin wasn't loading. I guess it's case sensitive since it would default to not_provided without the capital S.